### PR TITLE
fix: Threaded Optimization offloading logic

### DIFF
--- a/docs/getting-started/post-installation/drivers/gpu/nvidia.md
+++ b/docs/getting-started/post-installation/drivers/gpu/nvidia.md
@@ -29,7 +29,7 @@ This section was partly based on [AMIT's documentation](https://github.com/amitx
     - Power management mode - Prefer maximum performance
     - Shader Cache Size - Unlimited
     - Texture filtering - Quality - High performance
-    - Threaded Optimization - Offloads GPU-related processing tasks on the CPU, it usually hurts frame pacing. If you are CPU bottlenecked, choose the ``On`` option.
+    - Threaded Optimization - Offloads GPU-related processing tasks on the CPU, it usually hurts frame pacing. If you are CPU bottlenecked, choose the ``Off`` option.
     - Vertical sync - Off
 - Configure the following in the ``Display -> Change resolution`` page:
     - Configure your monitor resolution and refresh rate.


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation.
- [ ] Add/remove new pages.

### Questions
- [x] Did you preview on your local machine beforehand?
- [x] Did you follow our [commit handbook](https://github.com/Atlas-OS/docs/blob/master/.github/CONTRIBUTING.md#commit-message)?

### Describe your pull request

Whether this is a typo or deliberate, it is contradicting because you would not want the GPU to offload tasks onto the CPU when you are CPU bound hence threaded optimization should disabled.
