### PR TITLE
Notifications disabled by default instead of enabled

### DIFF
--- a/docs/getting-started/post-installation/atlas-folder/configuration.md
+++ b/docs/getting-started/post-installation/atlas-folder/configuration.md
@@ -70,7 +70,7 @@ Network Navigation pane is a part of network discovery and controls whether the 
 
 ## Notifications
 
-Notifications are a built-in feature in Windows that is used to show you notifications. On Atlas, we have enabled them by default. If you wish to disable them, run the `Disable Notifications.cmd` file in the `Notifications` folder and restart.
+Notifications are a built-in feature in Windows that is used to show you notifications. On Atlas, we have disabled them by default. If you wish to enable them, run the `Enable Notifications.cmd` file in the `Notifications` folder and restart.
 
 ## Power
 


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation.
- [ ] Add/remove new pages.

### Questions
- [ ] Did you preview on your local machine beforehand?
- [x] Did you follow our [commit handbook](https://github.com/Atlas-OS/docs/blob/master/.github/CONTRIBUTING.md#commit-message)?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [x] Did you commit to the `dev` branch and not `master`?

### Describe your pull request
Although notifications are ``disabled`` by default on atlas, the documentation states that they are ``enabled``. 
![image](https://github.com/Atlas-OS/docs/assets/140727743/f38196a9-0a62-44f0-b32c-cfd2c1d54e1c)
