### PR TITLE
feat(header): replace repo with Atlas Playbook

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,9 @@ site_name: Atlas Documentation
 site_url: https://docs.atlasos.net
 
 # https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository
-repo_url: https://github.com/Atlas-OS/docs
-repo_name: Atlas-OS/docs
-edit_uri: edit/master/docs/
+repo_url: https://github.com/Atlas-OS/Atlas
+repo_name: Atlas Playbook
+edit_uri: https://github.com/Atlas-OS/docs/edit/master/docs
 
 # https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#change-cookie-settings
 copyright: >

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ theme:
   icon:
     edit: material/file-edit
     view: material/file-eye
+    repo: fontawesome/brands/github-alt
 
 
 #


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
This PR replaces the header's repository with the Playbook repo instead of the docs repo.

![image](https://github.com/Atlas-OS/docs/assets/65787561/0806722d-3187-4a40-86f5-b954a36e1dec)

As the documentation concerns the Playbook, it makes sense for users to be informed about its repo instead. Plus, it allows users to see the current release easily.

The docs get virtually no outside contributors anyway, so changing it would not negatively impact it.

https://change-header-git-repo.atlasos-docs-enq.pages.dev/
