### PR TITLE
feat(installation guide): Windows.old clarification

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -114,7 +114,7 @@ You can find your network driver online by searching for your device/motherboard
 
 === "No USB Drive (recommended)"
 
-    Your current Windows installation should be moved to a `Windows.old` folder after reinstalling. You can delete this after reinstalling Windows, which will be covered later. However, you should still externally backup files before proceeding.
+    As a consequence of following this method, your current Windows installation should be automatically moved to a `Windows.old` folder after reinstalling. You can delete this folder after reinstalling Windows, which will be covered later. However, you should still externally backup files before proceeding.
 
     1. Disconnect any cables providing internet to your computer, such as an ethernet cable. Do not reconnect it until instructed to do so
 


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
As proven on the Atlas Discord server, the first sentence of the "no USB drive" method can be sometimes erroneously understood as a step the user needs to perform themselves, rather than just an informative statement. The sentence has been slightly reworded to correct that. 