### PR TITLE
Removed a space that broke command

### DIFF
--- a/docs/install-faq/decrypting-using-bitlocker.md
+++ b/docs/install-faq/decrypting-using-bitlocker.md
@@ -14,6 +14,6 @@ Device encryption is enabled by default on many Windows 11 laptops. Although thi
 
 1. Search for **cmd** in the Start menu, right-click on it, and select **Run as administrator**.
 1. Type `manage-bde -off %SystemDrive%` and press ++enter++. This command starts the decryption process.
-    - If you see the error message ["This volume stores external key(s) that can automatically unlock other volumes"](../assets/images/bitlocker-error-decrypting.jpg), type `manage-bde -autounlock - ClearAllKeys %SystemDrive%` and press ++enter++ to clear the keys. After completion, re-type `manage-bde -off %SystemDrive%` and press ++enter++ to continue decrypting.
+    - If you see the error message ["This volume stores external key(s) that can automatically unlock other volumes"](../assets/images/bitlocker-error-decrypting.jpg), type `manage-bde -autounlock -ClearAllKeys %SystemDrive%` and press ++enter++ to clear the keys. After completion, re-type `manage-bde -off %SystemDrive%` and press ++enter++ to continue decrypting.
 1. If you see the message **Decryption is now in progress**, you have completed the steps correctly. The decryption process will take some time.
 1. To check the progress, type `manage-bde -status` and look at the ["Percentage Encrypted"](../assets/images/bitlocker-decryption-progress.webp). Once it has reached **0%**, you've successfully decrypted the drive!


### PR DESCRIPTION
The command is: manage-bde -autounlock -ClearAllKeys %SystemDrive%

The command that was told in the website was  manage-bde -autounlock -ClearAllKeys %SystemDrive% which gave an output of: "-" was not understood.

### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
