### PR TITLE
Fix styling for buttons in ISO download section

### DIFF
--- a/docs/javascript/msdl.v1.js
+++ b/docs/javascript/msdl.v1.js
@@ -110,6 +110,7 @@ function langJsonStrToHTML(jsonStr) {
     button.textContent = "Download";
     button.disabled = true;
     button.setAttribute("onClick", "getDownload();");
+    button.classList = "msdl-button";
     container.appendChild(button);
 
     return container.innerHTML;

--- a/includes/msdl.md
+++ b/includes/msdl.md
@@ -12,10 +12,10 @@
     document.head.appendChild(styleSheet)
 </script>
 
-<center class="noJs centerMsdl">
+<center markdown class="noJs centerMsdl">
 <div class="msdl-button-container">
-    <button markdown class="msdl-button" style="margin-right: 2px" onclick="getWindows({{ msdl.win11.pid }});">Download Windows 11 {{ msdl.win11.version }}</button>
-    <button markdown class="msdl-button" style="margin-left: 2px" onclick="getWindows({{ msdl.win10.pid }});">Download Windows 10 {{ msdl.win10.version }}</button>
+    <button markdow class="msdl-button" style="margin-right: 2px" onclick="getWindows({{ msdl.win11.pid }});">Download Windows 11 {{ msdl.win11.version }}</button>
+    <button markdow class="msdl-button" style="margin-left: 2px" onclick="getWindows({{ msdl.win10.pid }});">Download Windows 10 {{ msdl.win10.version }}</button>
 </div>
 
 <div id="msdl-ms-content"></div>

--- a/includes/msdl.md
+++ b/includes/msdl.md
@@ -14,7 +14,7 @@
 
 <center markdown class="noJs centerMsdl">
 <div class="msdl-button-container">
-    <button markdow class="msdl-button" style="margin-right: 2px" onclick="getWindows({{ msdl.win11.pid }});">Download Windows 11 {{ msdl.win11.version }}</button>
+    <button markdown class="msdl-button" style="margin-right: 2px" onclick="getWindows({{ msdl.win11.pid }});">Download Windows 11 {{ msdl.win11.version }}</button>
     <button markdown class="msdl-button" style="margin-left: 2px" onclick="getWindows({{ msdl.win10.pid }});">Download Windows 10 {{ msdl.win10.version }}</button>
 </div>
 

--- a/includes/msdl.md
+++ b/includes/msdl.md
@@ -15,7 +15,7 @@
 <center markdown class="noJs centerMsdl">
 <div class="msdl-button-container">
     <button markdow class="msdl-button" style="margin-right: 2px" onclick="getWindows({{ msdl.win11.pid }});">Download Windows 11 {{ msdl.win11.version }}</button>
-    <button markdow class="msdl-button" style="margin-left: 2px" onclick="getWindows({{ msdl.win10.pid }});">Download Windows 10 {{ msdl.win10.version }}</button>
+    <button markdown class="msdl-button" style="margin-left: 2px" onclick="getWindows({{ msdl.win10.pid }});">Download Windows 10 {{ msdl.win10.version }}</button>
 </div>
 
 <div id="msdl-ms-content"></div>


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
Fixed the bad styling when downloading an ISO in the getting started section