### PR TITLE
getting started, step 5 - changed order of instructions for clarity

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -325,7 +325,7 @@ If you don't know, choose 'Driver Installation & Updates from Windows Update.'
 
 1. Extract both downloads to your desktop
 
-    !!! note "Manual Driver installation"
+    !!! info ""
 		**If you have chosen [**Manual Driver Installation**](#driver-updates)**, run `Disable Drivers Installation in Windows Update.reg` from the extracted Atlas Playbook download and restart
 	
 1. Open `AME Wizard Beta.exe` from the AME Wizard folder


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation

### Questions
- [x] Did you preview your changes beforehand?
Yes
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
Yes

### Describe your pull request

I changed the order of instructions in step 5 of getting-started
1 - 3 were moved after 7 so that the instructions for updating Windows come first
the number in step 4. is removed. The “if” part of the sentence is highlighted and moved to the first position, separate from the other steps

This should make it clearer that Windows should be updated before installing AtlasOS, and the manual driver installation step is separated from the other steps to avoid confusion

<img width="1976" height="1212" alt="installingAtlasOSedit" src="https://github.com/user-attachments/assets/e7c2301c-d4fe-41a8-b104-fe649aea9fef" />