### PR TITLE
fix: hide Windows 11 alternative download methods

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,15 +50,11 @@ See the alternatives below.
     !!! tip 
         Even though the downloader we use in our docs use Microsoft's servers, you can also download the ISO directly from Microsoft or use the Windows Media Creation Tool.
 
+    !!! warning
+        Both of the following alternative download methods will download the 25H2 version of Windows 11, which is not yet supported by Atlas. Please use the "Download Windows 11 24H2" button below this section instead.
+
     <div id="official-microsoft-sources"></div>
     === "Official Microsoft Sources"
-
-        ### [Windows 11 :material-download:](https://www.microsoft.com/en-us/software-download/windows11)
-
-        - Click the link above and **scroll down** to **Download Windows 11 Disk Image (ISO) for x64 devices.**<br> **DO NOT** use the **Installation Assistant** or **Create Windows 11 Installation Media.**
-        - Select **Windows 11 (multi-edition ISO for x64 devices)** and click **Download Now.**
-        - Select your desired language and press confirm.
-        - Click **64-bit Download** to begin your download.
 
         ### [Windows 10 :material-download:](https://www.microsoft.com/en-us/software-download/windows10ISO)
 
@@ -68,11 +64,11 @@ See the alternatives below.
 
     === "Windows Media Creation Tool"
 
-        1. Download the [Windows 10 :material-download:](https://go.microsoft.com/fwlink/?LinkId=691209) or [Windows 11 :material-download:](https://go.microsoft.com/fwlink/?linkid=2156295) Media Creation Tool, then open it
+        1. Download the [Windows 10 :material-download:](https://go.microsoft.com/fwlink/?LinkId=691209) Media Creation Tool, then open it
         1. Click the **Accept** button to agree to the Microsoft license terms
         1. Select **Create installation media (USB flash drive, DVD, or ISO file) for another PC**, click **Next**, and choose:
             - **Language:** Your desired language
-            - **Edition:** Windows 10 or 11
+            - **Edition:** Windows 10
             - **Architecture (Windows 10 only):** 64-bit (x64)
         1. Choose the **ISO file** option, then choose the download location
         1. After the ISO has completed downloading, click **Finish**


### PR DESCRIPTION
### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
Hides the Windows 11 downloads from the "Altenatives" section of the installation guide, as both of these methods will download a currently unsupported 25H2 version of the system. Also adds a warning about this.

<img width="783" height="702" alt="image" src="https://github.com/user-attachments/assets/c952b3fc-27c8-4609-82db-bcf6cba021b6" />
