### PR TITLE
Fix link to AME Wizard backend in security FAQ

### DIFF
--- a/docs/general-faq/atlas-and-security.md
+++ b/docs/general-faq/atlas-and-security.md
@@ -15,7 +15,7 @@ Additionally, you can always change security post-install.
 
 Fundamentally, unmodified Windows from Microsoft will always be the most trusted and secure version of Windows available.
 
-Regardless, Atlas aims to have similar parity with unmodified Windows' security while being as transparent as possible. [Atlas is open source on GitHub](https://github.com/Atlas-OS/Atlas), and Ameliorated's AME Wizard, utilized by Atlas to make changes, has its [backend open source under MIT](https://git.ameliorated.info/Styris/trusted-uninstaller-cli).
+Regardless, Atlas aims to have similar parity with unmodified Windows' security while being as transparent as possible. [Atlas is open source on GitHub](https://github.com/Atlas-OS/Atlas), and Ameliorated's AME Wizard, utilized by Atlas to make changes, has its [backend open source under MIT](https://github.com/Ameliorated-LLC/trusted-uninstaller-cli).
 
 ## :material-timeline-question: Legacy versions of Atlas
 


### PR DESCRIPTION
Updated the link for Ameliorated's AME Wizard backend to the correct GitHub repository.

### Type
- [x] Rewrite already written documentation
- [ ] Add/remove new pages

### Questions
- [x] Did you preview your changes beforehand?
- [x] Did you read the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

Changed old AME link which gave a 404 to the new working github link